### PR TITLE
Add relationships between certfiles and docker

### DIFF
--- a/manifests/app_stack.pp
+++ b/manifests/app_stack.pp
@@ -366,6 +366,14 @@ class hdp::app_stack (
     }
   }
 
+  # If TLS is enabled, ensure certificate files are present before docker does
+  # its thing and restart containers if the files change.
+  if $ui_use_tls {
+    File[$ui_key_file] ~> Docker_compose['hdp']
+    File[$ui_cert_file] ~> Docker_compose['hdp']
+    File[$ui_ca_cert_file] ~> Docker_compose['hdp']
+  }
+
   docker_compose { 'hdp':
     ensure        => present,
     compose_files => ['/opt/puppetlabs/hdp/docker-compose.yaml',],


### PR DESCRIPTION
Prior to this, a user would have to specify both require and subscribe
attributes on the hdp::app_stack resource to ensure certificate files
were in place prior to startup and and that containers were restarted
when the files change.