### PR TITLE
Fix ports used when tls is enabled

### DIFF
--- a/spec/classes/app_stack_spec.rb
+++ b/spec/classes/app_stack_spec.rb
@@ -14,6 +14,45 @@ describe 'hdp::app_stack' do
         it { is_expected.to  contain_file('/opt/puppetlabs/hdp').with_ensure('directory') }
         it { is_expected.to  contain_file('/opt/puppetlabs/hdp/docker-compose.yaml').with_content(%r{NAME=hdp\.test\.com}) }
         it { is_expected.to  contain_docker_compose('hdp').with_compose_files(['/opt/puppetlabs/hdp/docker-compose.yaml']) }
+        it { is_expected.to contain_file('/opt/puppetlabs/hdp/docker-compose.yaml').with_content(%r{- "80:80"}) }
+        it { is_expected.to contain_file('/opt/puppetlabs/hdp/docker-compose.yaml').without_content(%r{- "443:443"}) }
+      end
+
+      context 'with ui tls enabled' do
+        let(:pre_condition) do
+          <<-EOS
+            file { "/tmp/ui-ca.pem": ensure => present }
+            file { "/tmp/ui-cert.key": ensure => present }
+            file { "/tmp/ui-cert.pem": ensure => present }
+          EOS
+        end
+
+        let(:params) do
+          {
+            'dns_name' => 'hdp.test.com',
+            'ui_use_tls' => true,
+            'ui_ca_cert_file' => '/tmp/ui-ca.pem',
+            'ui_key_file' => '/tmp/ui-cert.key',
+            'ui_cert_file' => '/tmp/ui-cert.pem',
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to  contain_file('/tmp/ui-ca.pem').that_comes_before('Docker_compose[hdp]') }
+        it { is_expected.to  contain_file('/tmp/ui-cert.key').that_comes_before('Docker_compose[hdp]') }
+        it { is_expected.to  contain_file('/tmp/ui-cert.pem').that_comes_before('Docker_compose[hdp]') }
+        it {
+          is_expected.to contain_docker_compose('hdp').that_subscribes_to(
+            [
+              'File[/tmp/ui-ca.pem]',
+              'File[/tmp/ui-cert.key]',
+              'File[/tmp/ui-cert.pem]',
+              # 'File[/opt/puppetlabs/hdp/docker-compose.yaml]',
+            ],
+          )
+        }
+        it { is_expected.to contain_file('/opt/puppetlabs/hdp/docker-compose.yaml').with_content(%r{- "80:80"}) }
+        it { is_expected.to contain_file('/opt/puppetlabs/hdp/docker-compose.yaml').with_content(%r{- "443:443"}) }
       end
     end
   end

--- a/templates/docker-compose.yaml.epp
+++ b/templates/docker-compose.yaml.epp
@@ -3,7 +3,8 @@
       Optional[String] $image_repository,
       Integer $hdp_port,
       Integer $hdp_query_port,
-      Integer $hdp_ui_port,
+      Integer $hdp_ui_http_port,
+      Integer $hdp_ui_https_port,
 
       Boolean $hdp_manage_s3,
       String $hdp_s3_endpoint,
@@ -157,10 +158,9 @@ services:
   ui-frontend:
     image: "<% if $image_repository { %><%= $image_repository %>/<% } %><%= $image_prefix %>ui-frontend:<%= $hdp_version %>"
     ports:
+      - "<%= $hdp_ui_http_port %>:80"
 <%- if $ui_use_tls { %>
-      - "<%= $hdp_ui_port %>:443"
-<%- } else { %>
-      - "<%= $hdp_ui_port %>:80"
+      - "<%= $hdp_ui_https_port %>:443"
 <%- } %>
     environment:
       - "HDP_ENABLE_TLS=<%= $ui_use_tls %>"


### PR DESCRIPTION
Prior to this, the result of enabling tls was port 80 being sent to 443 in the container, which fails due to a protocol mismatch.