### PR TITLE
UI TLS doesn't need CA set

### DIFF
--- a/manifests/app_stack.pp
+++ b/manifests/app_stack.pp
@@ -383,7 +383,10 @@ class hdp::app_stack (
   if $ui_use_tls and $ui_cert_files_puppet_managed {
     File[$ui_key_file] ~> Docker_compose['hdp']
     File[$ui_cert_file] ~> Docker_compose['hdp']
-    File[$ui_ca_cert_file] ~> Docker_compose['hdp']
+
+    if $ui_ca_cert_file {
+      File[$ui_ca_cert_file] ~> Docker_compose['hdp']
+    }
   }
 
   docker_compose { 'hdp':

--- a/spec/classes/app_stack_spec.rb
+++ b/spec/classes/app_stack_spec.rb
@@ -25,7 +25,6 @@ describe 'hdp::app_stack' do
       context 'with ui tls enabled' do
         let(:pre_condition) do
           <<-EOS
-            file { "/tmp/ui-ca.pem": ensure => present }
             file { "/tmp/ui-cert.key": ensure => present }
             file { "/tmp/ui-cert.pem": ensure => present }
           EOS
@@ -35,20 +34,17 @@ describe 'hdp::app_stack' do
           {
             'dns_name' => 'hdp.test.com',
             'ui_use_tls' => true,
-            'ui_ca_cert_file' => '/tmp/ui-ca.pem',
             'ui_key_file' => '/tmp/ui-cert.key',
             'ui_cert_file' => '/tmp/ui-cert.pem',
           }
         end
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to  contain_file('/tmp/ui-ca.pem').that_comes_before('Docker_compose[hdp]') }
         it { is_expected.to  contain_file('/tmp/ui-cert.key').that_comes_before('Docker_compose[hdp]') }
         it { is_expected.to  contain_file('/tmp/ui-cert.pem').that_comes_before('Docker_compose[hdp]') }
         it {
           is_expected.to contain_docker_compose('hdp').that_subscribes_to(
             [
-              'File[/tmp/ui-ca.pem]',
               'File[/tmp/ui-cert.key]',
               'File[/tmp/ui-cert.pem]',
               'File[/opt/puppetlabs/hdp/docker-compose.yaml]',
@@ -57,6 +53,48 @@ describe 'hdp::app_stack' do
         }
         it { is_expected.to contain_file('/opt/puppetlabs/hdp/docker-compose.yaml').with_content(%r{- "80:80"}) }
         it { is_expected.to contain_file('/opt/puppetlabs/hdp/docker-compose.yaml').with_content(%r{- "443:443"}) }
+
+        context 'with ui_ca_cert_file specified' do
+          let(:pre_condition) do
+            <<-EOS
+              file { "/tmp/ui-ca.pem": ensure => present }
+              file { "/tmp/ui-cert.key": ensure => present }
+              file { "/tmp/ui-cert.pem": ensure => present }
+            EOS
+          end
+
+          let(:params) do
+            {
+              'dns_name' => 'hdp.test.com',
+              'ui_use_tls' => true,
+              'ui_ca_cert_file' => '/tmp/ui-ca.pem',
+              'ui_key_file' => '/tmp/ui-cert.key',
+              'ui_cert_file' => '/tmp/ui-cert.pem',
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it {
+            is_expected.to contain_docker_compose('hdp')
+              .with_compose_files(['/opt/puppetlabs/hdp/docker-compose.yaml'])
+              .that_requires(
+                [
+                  'File[/tmp/ui-ca.pem]',
+                  'File[/tmp/ui-cert.key]',
+                  'File[/tmp/ui-cert.pem]',
+                  'File[/opt/puppetlabs/hdp/docker-compose.yaml]',
+                ],
+              )
+              .that_subscribes_to(
+                [
+                  'File[/tmp/ui-ca.pem]',
+                  'File[/tmp/ui-cert.key]',
+                  'File[/tmp/ui-cert.pem]',
+                  'File[/opt/puppetlabs/hdp/docker-compose.yaml]',
+                ],
+              )
+          }
+        end
       end
     end
   end


### PR DESCRIPTION
It can be set, but is not required when just adding certs for the frontend web interface