### PR TITLE
Seperate versions

### DIFF
--- a/manifests/app_stack.pp
+++ b/manifests/app_stack.pp
@@ -68,7 +68,7 @@
 #   Image repository to pull images from - defaults to dockerhub.
 #   Can be used for airgapped environments/testing environments
 #
-# @param [String[1]] image_prefix
+# @param [String] image_prefix
 #   Prefix that comes before each image
 #   Can be used for easy name spacing under the same repository
 #
@@ -196,7 +196,7 @@ class hdp::app_stack (
   Boolean $hdp_s3_force_path_style = true,
   Boolean $hdp_s3_disable_ssl = true,
 
-  String[1] $image_prefix = 'puppet/hdp-',
+  String $image_prefix = 'puppet/hdp-',
   String[1] $hdp_version = '0.0.1',
   Optional[String[1]] $ui_version = undef,
   Optional[String[1]] $frontend_version = undef,

--- a/manifests/app_stack.pp
+++ b/manifests/app_stack.pp
@@ -123,7 +123,15 @@
 #   Extra dns names attached to the puppet cert, can be used to bypass certname collisions
 #
 # @param [String[1]] hdp_version
-#   The version of the HDP containers to use
+#   The version of the HDP Data container to use
+#
+# @param [Optional[String[1]]] ui_version
+#   The version of the HDP UI container to use
+#   If undef, defaults to hdp_version
+#
+# @param [Optional[String[1]]] frontend_version
+#   The version of the HDP UI TLS Frontend container to use
+#   If undef, defaults to hdp_version
 #
 # @param [String[1]] log_driver
 #   The log driver Docker will use
@@ -190,6 +198,8 @@ class hdp::app_stack (
 
   String[1] $image_prefix = 'puppet/hdp-',
   String[1] $hdp_version = '0.0.1',
+  Optional[String[1]] $ui_version = undef,
+  Optional[String[1]] $frontend_version = undef,
   String[1] $log_driver = 'journald',
   String[1] $max_es_memory = '4G',
 ) {
@@ -242,6 +252,18 @@ class hdp::app_stack (
     $_final_hdp_s3_force_path_style=$hdp_s3_force_path_style
   }
 
+  if !$ui_version {
+    $_final_ui_version = $hdp_version
+  } else {
+    $_final_ui_version = $ui_version
+  }
+
+  if !$frontend_version {
+    $_final_frontend_version = $hdp_version
+  } else {
+    $_final_frontend_version = $frontend_version
+  }
+
   file {
     default:
       ensure  => directory,
@@ -265,6 +287,8 @@ class hdp::app_stack (
       group   => 'docker',
       content => epp('hdp/docker-compose.yaml.epp', {
           'hdp_version'             => $hdp_version,
+          'ui_version'              => $_final_ui_version,
+          'frontend_version'        => $_final_frontend_version,
           'image_prefix'            => $image_prefix,
           'image_repository'        => $image_repository,
           'hdp_port'                => $hdp_port,

--- a/spec/classes/app_stack_spec.rb
+++ b/spec/classes/app_stack_spec.rb
@@ -162,6 +162,27 @@ describe 'hdp::app_stack' do
             .with_content(%r{hub.docker.com/ui-frontend:baz})
         }
       end
+
+      context 'with same versions' do
+        let(:params) do
+          {
+            'dns_name' => 'hdp.test.com',
+            'image_repository' => 'hub.docker.com',
+            'image_prefix' => '',
+            'hdp_version' => 'foo',
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it {
+          is_expected.to contain_file('/opt/puppetlabs/hdp/docker-compose.yaml')
+            .with_owner('root')
+            .with_group('docker')
+            .with_content(%r{hub.docker.com/data-ingestion:foo})
+            .with_content(%r{hub.docker.com/ui:foo})
+            .with_content(%r{hub.docker.com/ui-frontend:foo})
+        }
+      end
     end
   end
 end

--- a/spec/classes/app_stack_spec.rb
+++ b/spec/classes/app_stack_spec.rb
@@ -8,10 +8,10 @@ describe 'hdp::app_stack' do
 
       context 'with defaults' do
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to  contain_group('docker').with_ensure('present') }
-        it { is_expected.to  contain_class('docker').with_log_driver('journald') }
-        it { is_expected.to  contain_class('docker::compose').with_ensure('present') }
-        it { is_expected.to  contain_file('/opt/puppetlabs/hdp').with_ensure('directory') }
+        it { is_expected.to contain_group('docker').with_ensure('present') }
+        it { is_expected.to contain_class('docker').with_log_driver('journald') }
+        it { is_expected.to contain_class('docker::compose').with_ensure('present') }
+        it { is_expected.to contain_file('/opt/puppetlabs/hdp').with_ensure('directory') }
         it {
           is_expected.to contain_docker_compose('hdp')
             .with_compose_files(['/opt/puppetlabs/hdp/docker-compose.yaml'])
@@ -138,6 +138,29 @@ describe 'hdp::app_stack' do
               )
           }
         end
+      end
+
+      context 'with seperate versions' do
+        let(:params) do
+          {
+            'dns_name' => 'hdp.test.com',
+            'image_repository' => 'hub.docker.com',
+            'image_prefix' => '',
+            'hdp_version' => 'foo',
+            'ui_version' => 'bar',
+            'frontend_version' => 'baz',
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it {
+          is_expected.to contain_file('/opt/puppetlabs/hdp/docker-compose.yaml')
+            .with_owner('root')
+            .with_group('docker')
+            .with_content(%r{hub.docker.com/data-ingestion:foo})
+            .with_content(%r{hub.docker.com/ui:bar})
+            .with_content(%r{hub.docker.com/ui-frontend:baz})
+        }
       end
     end
   end

--- a/templates/docker-compose.yaml.epp
+++ b/templates/docker-compose.yaml.epp
@@ -1,4 +1,6 @@
 <%- | String $hdp_version,
+      String $ui_version,
+      String $frontend_version,
       String $image_prefix,
       Optional[String] $image_repository,
       Integer $hdp_port,
@@ -156,7 +158,7 @@ services:
       - "<%= $root_dir %>/redis:/data"
     command: "redis-server --appendonly yes"
   ui-frontend:
-    image: "<% if $image_repository { %><%= $image_repository %>/<% } %><%= $image_prefix %>ui-frontend:<%= $hdp_version %>"
+    image: "<% if $image_repository { %><%= $image_repository %>/<% } %><%= $image_prefix %>ui-frontend:<%= $frontend_version %>"
     ports:
       - "<%= $hdp_ui_http_port %>:80"
 <%- if $ui_use_tls { %>
@@ -172,7 +174,7 @@ services:
       - "<%= $ui_cert_file %>:/etc/ssl/cert.pem:ro"
 <%- } %>
   ui:
-    image: "<% if $image_repository { %><%= $image_repository %>/<% } %><%= $image_prefix %>ui:<%= $hdp_version %>"
+    image: "<% if $image_repository { %><%= $image_repository %>/<% } %><%= $image_prefix %>ui:<%= $ui_version %>"
     environment:
       - "PORT=3000"
 <%- if $ui_use_tls { %>


### PR DESCRIPTION
Add parameters that let the app_stack specify uniquer versions of each component. This will help with integration tests, where want to try a mixed and matched tag set before deploying for real.